### PR TITLE
Optional token + numerous fixes

### DIFF
--- a/src/structures/Rest.ts
+++ b/src/structures/Rest.ts
@@ -40,6 +40,14 @@ export default class Rest extends EventEmitter {
 		else req.headers = new Headers({ [header]: value });
 	}
 
+	public static hasHeader(req: RequestInit, header: string) {
+		if (Array.isArray(req.headers)) return req.headers.some(([name]) => name === header);
+		else if (req.headers instanceof Headers) return req.headers.has(header);
+		else if (req.headers) return Object.keys(req.headers).includes(header);
+
+		return false;
+	}
+
 	public options: Options;
 	public buckets: Map<string, Bucket> = new Map();
 
@@ -149,7 +157,7 @@ export default class Rest extends EventEmitter {
 
 		if (req.reason) Rest.setHeader(req, 'X-Audit-Log-Reason', req.reason);
 
-		if (this.options.token) {
+		if (this.options.token && !Rest.hasHeader(req, 'Authorization')) {
 			Rest.setHeader(req, 'Authorization', `${this.options.tokenType} ${this.options.token}`);
 		}
 

--- a/src/structures/Rest.ts
+++ b/src/structures/Rest.ts
@@ -152,7 +152,7 @@ export default class Rest extends EventEmitter {
 			else form.append(req.files.name, req.files.file, req.files.name);
 			if (typeof req.body !== 'undefined') form.append('payload_json', req.body);
 			req.body = form;
-			Rest.setHeaders(req, form.getHeaders());
+			Rest.setHeader(req, 'Content-Type', form.getHeaders()['content-type']);
 		}
 
 		if (req.reason) Rest.setHeader(req, 'X-Audit-Log-Reason', req.reason);

--- a/src/structures/Rest.ts
+++ b/src/structures/Rest.ts
@@ -12,6 +12,7 @@ import * as pkg from '../../package.json';
 export enum TokenType {
 	BOT = 'Bot',
 	BEARER = 'Bearer',
+	BASIC = 'Basic',
 }
 
 export interface Options {


### PR DESCRIPTION
- Allow the token to be optional
- Don't override an existing Authorization header
- Add missing Basic token type (https://tools.ietf.org/html/rfc6749#section-2.3.1)
- Fix form-data adding a `content-type` header causing conflict with `Content-Type`